### PR TITLE
Anaconda Kickstart Support

### DIFF
--- a/fedora-photon-pony.yaml
+++ b/fedora-photon-pony.yaml
@@ -26,14 +26,16 @@ packages:
   - gcc
   - htop
   - btop
-  - nginx
   # PhotonPonyOS specific packages
   - ppos-repos
   - ppos-repos-ostree
   - aps-root-cert
   - opalkelly
   - dib
-  - spcm4
+  # - spcm4
+  - aps-nginx
+  - aps-frontend
+  # - aps-http-gateway
   # Needs to be installed after the fact since this package has broken post install requirements.
   # More: https://discussion.fedoraproject.org/t/rpm-ostree-compose-including-akmods-rpm/84624/1
   # - spcm4-akmod

--- a/justfile
+++ b/justfile
@@ -326,7 +326,8 @@ lorax variant=default_variant arch=default_arch:
         --add-template-var=ostree_update_ref=fedora/${version}/${arch}/${variant} \
         ${pwd}/iso/linux
     
-    just kickstart iso/linux/images/boot.iso iso/Fedora-${volid_sub}-ostree-${arch}-${version_pretty}-${buildid}.iso
+    mv iso/linux/images/boot.iso iso/Fedora-${volid_sub}-ostree-${arch}-${version_pretty}-${buildid}.iso
+    just kickstart iso/Fedora-${volid_sub}-ostree-${arch}-${version_pretty}-${buildid}.iso iso/KS-Fedora-${volid_sub}-ostree-${arch}-${version_pretty}-${buildid}.iso
     just fix-ownership
 
 kickstart inputIso outputIso:

--- a/justfile
+++ b/justfile
@@ -302,7 +302,7 @@ lorax variant=default_variant arch=default_arch:
     pwd="$(pwd)"
 
     lorax \
-        --product=Fedora \
+        --product=PhotonPonyOS \
         --version=${version_pretty} \
         --release=${buildid} \
         --source="${source_url}" \
@@ -319,15 +319,20 @@ lorax variant=default_variant arch=default_arch:
         --add-template=${pwd}/fedora-lorax-templates/ostree-based-installer/lorax-embed-repo.tmpl \
         --add-template-var=ostree_install_repo=file://${pwd}/repo \
         --add-template-var=ostree_update_repo=file://${pwd}/repo \
-        --add-template-var=ostree_osname=fedora \
+        --add-template-var=ostree_osname=ppos \
         --add-template-var=ostree_oskey=fedora-${version_number}-primary \
         --add-template-var=ostree_contenturl=mirrorlist=https://ostree.fedoraproject.org/mirrorlist \
         --add-template-var=ostree_install_ref=fedora/${version}/${arch}/${variant} \
         --add-template-var=ostree_update_ref=fedora/${version}/${arch}/${variant} \
         ${pwd}/iso/linux
     
-    cp iso/linux/images/boot.iso iso/Fedora-${volid_sub}-ostree-${arch}-${version_pretty}-${buildid}.iso
+    just kickstart iso/linux/images/boot.iso iso/Fedora-${volid_sub}-ostree-${arch}-${version_pretty}-${buildid}.iso
     just fix-ownership
+
+kickstart inputIso outputIso:
+    #!/bin/bash
+    set -euxo pipefail
+    mkksiso $(pwd)/ppos.ks {{inputIso}} {{outputIso}}
 
 upload-container variant=default_variant:
     #!/bin/bash

--- a/ppos.ks
+++ b/ppos.ks
@@ -36,8 +36,15 @@ firstboot --disable
 
 # Partition clearing information
 ignoredisk --only-use=vda
-autopart
 clearpart --none --initlabel
+part /boot/efi --fstype="efi" --ondisk=vda --size=600 --fsoptions="umask=0077,shortname=winnt"
+part /boot --fstype="ext4" --ondisk=vda --size=1024
+part btrfs.114 --fstype="btrfs" --ondisk=vda --grow --maxsize=10000000000000 # Some really large value since we want the partition to take all left over space.
+btrfs none --label=photonponyos --data=single btrfs.114
+btrfs / --subvol --name=root LABEL=photonponyos
+btrfs /home --subvol --name=home LABEL=photonponyos
+btrfs /opt/webcache --subvol --name=opt_webcache LABEL=photonponyos
+btrfs /opt --subvol --name=opt LABEL=photonponyos
 
 # System timezone
 timezone Europe/Berlin --utc

--- a/ppos.ks
+++ b/ppos.ks
@@ -1,0 +1,50 @@
+# Documentation is not really existent. The easies is to take a look at the tests found here: https://github.com/pykickstart/pykickstart/blob/master/tests/ 
+# Misc: https://wiki.centos.org/TipsAndTricks/KickStart
+
+# Use graphical install
+graphical
+
+%post --erroronfail --log=/root/my-post-log
+cp /etc/skel/.bash* /root
+
+# Allow adding users to the dialout group later on
+# Ref: https://docs.fedoraproject.org/en-US/fedora-silverblue/troubleshooting/#_unable_to_add_user_to_group
+grep -E '^dialout:' /usr/lib/group >> /etc/group
+%end
+
+# Not supported with rpm-ostree
+# %packages
+# @core
+# %end
+
+# Keyboard layouts
+keyboard --vckeymap=de --xlayouts='de'
+# System language
+lang en_US.UTF-8
+
+# Firewall configuration
+firewall --enabled --ssh --port=80:tcp,443:tcp
+
+# OSTree setup
+ostreesetup --osname="ppos" --remote="ppos-compose" --url="file:///ostree/repo" --ref="fedora/38/x86_64/photon-pony" --nogpg
+
+# Disable the Setup Agent on first boot
+firstboot --disable
+
+# Ask for network configuration
+# network --device=eth0 --bootproto=query
+
+# Partition clearing information
+ignoredisk --only-use=vda
+autopart
+clearpart --none --initlabel
+
+# System timezone
+timezone Europe/Berlin --utc
+
+#Root password
+rootpw --lock
+user --groups=wheel --name=fabian --password=$y$j9T$0EF1wDrjYvNDtiG1vc8AKH4e$8lIjOhWZlgHy/7jZtksK9dYxXUECxWDRP6ZpJg2BtpC --iscrypted --gecos="fabian"
+
+# Make sure SELinux is enabled
+selinux --enforcing


### PR DESCRIPTION
Adds support for an Anaconda Kickstart script that will automate the installation process. This Kickstart script includes:
* Support for BTRFS subvolumes
* Fixing the ostree groups issue mentioned [here](https://docs.fedoraproject.org/en-US/fedora-silverblue/troubleshooting/#_unable_to_add_user_to_group)
* Enabling the firewall and opening the TCP ports `80` and `443`
* Enabling SELinux