### PR TITLE
Kickstart /usr/local sub-volume

### DIFF
--- a/ppos.ks
+++ b/ppos.ks
@@ -45,6 +45,7 @@ btrfs / --subvol --name=root LABEL=photonponyos
 btrfs /home --subvol --name=home LABEL=photonponyos
 btrfs /opt/webcache --subvol --name=opt_webcache LABEL=photonponyos
 btrfs /opt --subvol --name=opt LABEL=photonponyos
+btrfs /usr/local --subvol --name=usr_local LABEL=photonponyos
 
 # System timezone
 timezone Europe/Berlin --utc


### PR DESCRIPTION
Adds the missing logical BTRFS sub-volume for `/usr/local` to reflect the file system architecture of [Fedora Silverblue](https://docs.fedoraproject.org/en-US/fedora-silverblue/technical-information/#filesystem-layout).