### PR TITLE
just Command For Exporting The Last Commit of a Ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /logs/
 /repo/
 /tmp/
+/release/


### PR DESCRIPTION
Allows exporting the last commit of a given ref as a separate repo. This is useful for offline updates. The exported commit also gets signed with the provided fingerprint.

Example:
```
sudo just export-release photon-pony-base <gpg-key-fingerprint>
```

This then produces a new `.zip` file inside the `release` directory.