### PR TITLE
PhotonPonyOS Base

### DIFF
--- a/fedora-photon-pony-base.yaml
+++ b/fedora-photon-pony-base.yaml
@@ -1,0 +1,46 @@
+# Treefile documentation: https://rpm-ostree.readthedocs.io/en/stable/manual/treefile/
+
+include: fedora-common-ostree.yaml
+ref: fedora/38/${basearch}/photon-pony-base
+rojig:
+  name: fedora-photon-pony-base
+  summary: "PhotonPonyOSBase"
+  license: GPLv3
+packages:
+  # - fedora-release-silverblue
+  - PPOS-release
+  - gvfs-afc
+  - gvfs-afp
+  - gvfs-archive
+  - gvfs-fuse
+  - gvfs-goa
+  - gvfs-gphoto2
+  - gvfs-mtp
+  - gvfs-smb
+  - libcanberra-gtk3
+  - libproxy-duktape
+  - librsvg2
+  - libsane-hpaio
+  - mesa-dri-drivers
+  - mesa-libEGL
+  - git
+  - gcc
+  - htop
+  - btop
+  # PhotonPonyOS specific packages
+  - ppos-repos
+  - ppos-repos-ostree
+  - aps-root-cert
+
+repos:
+  - fedora-38
+  - fedora-38-updates
+  - ppos-38
+  - ppos-noarch-38
+
+units:
+  - NetworkManager.service
+  - firewalld.service
+  - sshd.service
+
+documentation: false

--- a/fedora-photon-pony-base.yaml
+++ b/fedora-photon-pony-base.yaml
@@ -7,8 +7,7 @@ rojig:
   summary: "PhotonPonyOSBase"
   license: GPLv3
 packages:
-  # - fedora-release-silverblue
-  - PPOS-release
+  - fedora-release-silverblue
   - gvfs-afc
   - gvfs-afp
   - gvfs-archive

--- a/fedora-photon-pony.yaml
+++ b/fedora-photon-pony.yaml
@@ -32,44 +32,9 @@ packages:
   - aps-root-cert
   - opalkelly
   - dib
-  # - spcm4
-  - aps-nginx
   - aps-frontend
-  # - aps-http-gateway
-  # Needs to be installed after the fact since this package has broken post install requirements.
-  # More: https://discussion.fedoraproject.org/t/rpm-ostree-compose-including-akmods-rpm/84624/1
-  # - spcm4-akmod
-  # Misc dev dependencies
-  - python3
-  - python3-pip
-  - python3-devel
-  - git
-  - clang
-  - clang-tools-extra
-  - gcc
-  - gdb
-  - make
-  - libasan
-  - libubsan
-  - liblsan
-  - libtsan
-  - cmake
-  - gcovr
-  - pigz
-  - cppcheck
-  - grpc-plugins
-  - grpc-devel
-  - abseil-cpp-devel
-  - soci-devel
-  - libudev-devel
-  - dotnet-sdk-6.0
-  - doxygen plantuml
-  - nuget
-  - dbus
-  - dbus-devel
-  - NetworkManager
-  - procps-ng
-  - conan
+  - aps-http-gateway
+  - aps-botdr-backend
 
 repos:
   - fedora-38

--- a/justfile
+++ b/justfile
@@ -12,10 +12,10 @@ force_nocache := "false"
 # The default architecture we are building for. Set by default to the system architecture
 default_arch := "$(arch)"
 
-# Default is to compose Silverblue and Kinoite
+# Default is to compose PhotonPonyOS and PhotonPonyOSBase
 all:
     just compose photon-pony
-    just compose base
+    just compose photon-pony-base
 
 # Basic validation to make sure the manifests are not completely broken
 validate:
@@ -49,6 +49,9 @@ manifest variant=default_variant:
     case "${variant}" in
         "photon-pony")
             variant_pretty="PhotonPonyOS"
+            ;;
+        "photon-pony-base")
+            variant_pretty="PhotonPonyOSBase"
             ;;
         "*")
             echo "Unknown variant"
@@ -141,6 +144,9 @@ compose variant=default_variant:
         "photon-pony")
             variant_pretty="PhotonPonyOS"
             ;;
+        "photon-pony-base")
+            variant_pretty="PhotonPonyOSBase"
+            ;;
         "*")
             echo "Unknown variant"
             exit 1
@@ -168,7 +174,7 @@ compose variant=default_variant:
     echo "Composing ${variant_pretty} ${version}.${buildid} ..."
     # To debug with gdb, use: gdb --args ...
 
-    ARGS="--repo=repo --cachedir=cache"
+    ARGS="--repo=repo --layer-repo=repo --cachedir=cache"
     if [[ {{unified_core}} == "true" ]]; then
         ARGS+=" --unified-core"
     else
@@ -211,6 +217,9 @@ compose-image variant=default_variant:
     case "${variant}" in
         "photon-pony")
             variant_pretty="PhotonPonyOS"
+            ;;
+        "photon-pony-base")
+            variant_pretty="PhotonPonyOSBase"
             ;;
         "*")
             echo "Unknown variant"
@@ -329,6 +338,10 @@ lorax variant=default_variant arch=default_arch:
             variant_pretty="PhotonPonyOS"
             volid_sub="PPOS"
             ;;
+        "photon-pony-base")
+            variant_pretty="PhotonPonyOSBase"
+            volid_sub="PPOSBase"
+            ;;
         "*")
             echo "Unknown variant"
             exit 1
@@ -416,6 +429,9 @@ upload-container variant=default_variant:
         "photon-pony")
             variant_pretty="PhotonPonyOS"
             ;;
+        "photon-pony-base")
+            variant_pretty="PhotonPonyOSBase"
+            ;;
         "*")
             echo "Unknown variant"
             exit 1
@@ -482,6 +498,9 @@ archive variant=default_variant kind="repo":
     case "${variant}" in
         "photon-pony")
             variant_pretty="PhotonPonyOS"
+            ;;
+        "photon-pony-base")
+            variant_pretty="PhotonPonyOSBase"
             ;;
         "*")
             echo "Unknown variant"


### PR DESCRIPTION
Adds support for a basic version of PhotonPonyOS that does not contain any APS packages (except the repo and cert) so we can easily install and update dev versions of our applications.