### PR TITLE
Secure Boot Signing efi Files Failes for Unsigned Files

### DIFF
--- a/justfile
+++ b/justfile
@@ -193,7 +193,17 @@ compose-post-script secure_boot_db_sign_key_dir=default_secure_boot_db_sign_key_
     baseEfiPath="/usr/lib/ostree-boot/efi/EFI/fedora"
     find ${baseEfiPath} -name *.efi | while read -r path; do
         echo "Signing: ${path}"
-        pesign -r -u0 -i ${path} -o ${path}.empty || exit 1
+        sigCount=$(pesign -S -i ${path} | grep "Signing time" | wc -l)
+
+        # Not all efi files are signed. So skip removing signatures for all that are not signed.
+        if [[ ${sigCount} -ne 0 ]]; then
+            echo "Removing existing signature from: ${path}"
+            pesign -r -u0 -i ${path} -o ${path}.empty || exit 1
+        else
+            echo "No need to remove existing signature from '${path}'. There is none. Just copying..."
+            cp ${path} ${path}.empty
+        fi
+        
         sbsign ${path}.empty --key ${keyBasePath}/db.key --cert ${keyBasePath}/db.pem --output ${path} || exit 1
         rm -f ${path}.empty
     done

--- a/justfile
+++ b/justfile
@@ -193,9 +193,9 @@ compose-post-script secure_boot_db_sign_key_dir=default_secure_boot_db_sign_key_
     baseEfiPath="/usr/lib/ostree-boot/efi/EFI/fedora"
     find ${baseEfiPath} -name *.efi | while read -r path; do
         echo "Signing: ${path}"
-        sigCount=$(pesign -S -i ${path} | grep "Signing time" | wc -l)
 
         # Not all efi files are signed. So skip removing signatures for all that are not signed.
+        sigCount=$(pesign -S -i ${path} | grep "Signing time" | wc -l)
         if [[ ${sigCount} -ne 0 ]]; then
             echo "Removing existing signature from: ${path}"
             pesign -r -u0 -i ${path} -o ${path}.empty || exit 1


### PR DESCRIPTION
Fedora stopped shipping `shimia32.efi` with their key.
During the post process script we are signing all efi files available and therefore we remove the signatures first:
https://github.com/AP-Sensing/PhotonPonyOS/blob/2f4da9dde3d8c5f305bc4f7409335f1ef3adb100/justfile#L196

This fails since there is no signature available.

As a solution we should just skip removing if there is no signature available.