### PR TITLE
Including the spectrum kernel module inside the base image packages

### DIFF
--- a/fedora-photon-pony-base-packages.yaml
+++ b/fedora-photon-pony-base-packages.yaml
@@ -25,6 +25,8 @@ packages:
   - aps-root-cert
   - dts-n62-issue-msg
   - dts-n62-setup
+  # Install kernel modules inside the base image to avoid issues with layered kernel modules where rebuilding them fails since we are still booted with the old image/kernel-devel packages.
+  - akmod-spcm4
 
 repos:
   - fedora-38


### PR DESCRIPTION
This is to avoid issues with layered kernel modules where rebuilding them fails since we are still booted with the old image/kernel-devel packages.